### PR TITLE
Fixed misspelled getKernelImageId in MachineImage.java.

### DIFF
--- a/src/main/java/org/dasein/cloud/compute/MachineImage.java
+++ b/src/main/java/org/dasein/cloud/compute/MachineImage.java
@@ -285,7 +285,7 @@ public class MachineImage implements Taggable {
     /**
      * @return the kernel image associated with this machine image (this is a machine image if it is associated with a kernel image)
      */
-    public @Nullable String getKernelImaged() {
+    public @Nullable String getKernelImageId() {
         return kernelImageId;
     }
 


### PR DESCRIPTION
For https://github.com/greese/dasein-cloud-core/issues/50.

Wasn't sure which was easier - fixing it yourself based on the issue or pulling in a PR, so here's both. :)
