### PR TITLE
Added method to capture both nic and vm in single route

### DIFF
--- a/src/main/java/org/dasein/cloud/network/Route.java
+++ b/src/main/java/org/dasein/cloud/network/Route.java
@@ -66,6 +66,17 @@ public class Route {
         r.gatewayVirtualMachineId = vmId;
         return r;
     }
+
+    static public Route getRouteToVirtualMachineAndNetworkInterface(@Nonnull IPVersion version, @Nonnull String destination, @Nonnull String ownerId, @Nonnull String vmId, @Nonnull String nicId) {
+      Route r = new Route();
+
+      r.version = version;
+      r.destinationCidr = destination;
+      r.gatewayOwnerId = ownerId;
+      r.gatewayVirtualMachineId = vmId;
+      r.gatewayNetworkInterfaceId = nicId;
+      return r;
+    }
     
     private String    destinationCidr;
     private String    gatewayAddress;


### PR DESCRIPTION
coincides with a change from cloud-aws where concerning AWS responses such as:

https://gist.github.com/ckelner/6057527
