### PR TITLE
Added interface for offline storage request management

### DIFF
--- a/src/main/java/org/dasein/cloud/storage/AbstractStorageServices.java
+++ b/src/main/java/org/dasein/cloud/storage/AbstractStorageServices.java
@@ -47,7 +47,7 @@ public abstract class AbstractStorageServices implements StorageServices {
     }
 
     @Override
-    public @Nullable BlobStoreSupport getOfflineStorageSupport() {
+    public @Nullable OfflineStoreSupport getOfflineStorageSupport() {
         return null;
     }
 

--- a/src/main/java/org/dasein/cloud/storage/OfflineStoreRequest.java
+++ b/src/main/java/org/dasein/cloud/storage/OfflineStoreRequest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2009-2013 Dell, Inc.
+ * See annotations for authorship information
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+
+package org.dasein.cloud.storage;
+
+import org.dasein.util.uom.storage.*;
+import org.dasein.util.uom.storage.Byte;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * An abstracted offline storage request. This request may take hours to complete and
+ * the status may be queried using its request ID.
+ */
+public class OfflineStoreRequest {
+
+    private String                                    requestId;
+    private String                                    bucketName;
+    private String                                    objectName;
+    private OfflineStoreRequestAction                 action;
+    private String                                    actionDescription;
+    private Storage<org.dasein.util.uom.storage.Byte> size;
+    private String                                    description;
+    private OfflineStoreRequestStatus                 status;
+    private String                                    statusDescription;
+    private long                                      creationTimestamp;
+    private long                                      completionTimestamp;
+
+    public OfflineStoreRequest(String requestId, String bucketName, String objectName,
+                               OfflineStoreRequestAction action, String actionDescription,
+                               Storage<Byte> size, String description, OfflineStoreRequestStatus status,
+                               String statusDescription, long creationTimestamp, long completionTimestamp) {
+        this.requestId = requestId;
+        this.bucketName = bucketName;
+        this.objectName = objectName;
+        this.action = action;
+        this.actionDescription = actionDescription;
+        this.size = size;
+        this.description = description;
+        this.status = status;
+        this.statusDescription = statusDescription;
+        this.creationTimestamp = creationTimestamp;
+        this.completionTimestamp = completionTimestamp;
+    }
+
+    /**
+     * The provider-specific identifier for the request.
+     * @return the provider-specific request identifier
+     */
+    public @Nonnull String getRequestId() {
+        return requestId;
+    }
+
+    /**
+     * The name of the storage bucket being requested. This may be null for
+     * requests not pertaining to a specific bucket.
+     * @return storage bucket name
+     */
+    public @Nullable String getBucketName() {
+        return bucketName;
+    }
+
+    /**
+     * The name of the storage object being requested. This may be null for
+     * requests not pertaining to a specific object.
+     * @return storage object name
+     */
+    public @Nullable String getObjectName() {
+        return objectName;
+    }
+
+    /**
+     * The provider action for this request. Action types unknown to dasein
+     * will return as UNKNOWN
+     * @return request action
+     */
+    public @Nonnull OfflineStoreRequestAction getAction() {
+        return action;
+    }
+
+    /**
+     * The provider action description string
+     * @return request action description, specific to provider
+     */
+    public @Nullable String getActionDescription() {
+        return actionDescription;
+    }
+
+    /**
+     * The expected size of the request result. This may be null when this information
+     * is unavailable.
+     * @return size of request result, if available
+     */
+    public @Nullable Storage<org.dasein.util.uom.storage.Byte> getSize() {
+        return size;
+    }
+
+    /**
+     * The user or provider description of the request
+     * @return user or provider description of the request
+     */
+    public @Nullable String getDescription() {
+        return description;
+    }
+
+    /**
+     * Current status of the request
+     * @return status of request
+     */
+    public @Nonnull OfflineStoreRequestStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * Provider description of the request status
+     * @return provider description of request status
+     */
+    public @Nonnull String getStatusDescription() {
+        return statusDescription;
+    }
+
+    /**
+     * Timestamp of request creation
+     * @return timestamp of request creation
+     */
+    public long getCreationTimestamp() {
+        return creationTimestamp;
+    }
+
+    /**
+     * Timestamp of request completion. Will be -1 if request is not completed.
+     * @return timestamp of request completion, or -1
+     */
+    public long getCompletionTimestamp() {
+        return completionTimestamp;
+    }
+}

--- a/src/main/java/org/dasein/cloud/storage/OfflineStoreRequestAction.java
+++ b/src/main/java/org/dasein/cloud/storage/OfflineStoreRequestAction.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2009-2013 Dell, Inc.
+ * See annotations for authorship information
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+
+package org.dasein.cloud.storage;
+
+/**
+ * Possible actions for long term offline storage requests
+ */
+public enum OfflineStoreRequestAction {
+    LIST, DOWNLOAD, UNKNOWN
+}

--- a/src/main/java/org/dasein/cloud/storage/OfflineStoreRequestStatus.java
+++ b/src/main/java/org/dasein/cloud/storage/OfflineStoreRequestStatus.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2013 Dell, Inc.
+ * See annotations for authorship information
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+
+package org.dasein.cloud.storage;
+
+public enum OfflineStoreRequestStatus {
+    IN_PROGRESS, SUCCEEDED, FAILED
+}

--- a/src/main/java/org/dasein/cloud/storage/OfflineStoreSupport.java
+++ b/src/main/java/org/dasein/cloud/storage/OfflineStoreSupport.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2009-2013 Dell, Inc.
+ * See annotations for authorship information
+ *
+ * ====================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ====================================================================
+ */
+
+package org.dasein.cloud.storage;
+
+import org.dasein.cloud.CloudException;
+import org.dasein.cloud.InternalException;
+import org.dasein.cloud.identity.ServiceAction;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+
+/**
+ * Extends BlobStoreSupport with methods for potentially long-running offline storage requests
+ */
+public interface OfflineStoreSupport extends BlobStoreSupport {
+
+    static public final ServiceAction CREATE_REQUEST      = new ServiceAction("OFFLINESTORE:CREATE_REQUEST");
+    static public final ServiceAction GET_REQUEST         = new ServiceAction("OFFLINESTORE:GET_REQUEST");
+    static public final ServiceAction LIST_REQUEST        = new ServiceAction("OFFLINESTORE:LIST_REQUEST");
+    static public final ServiceAction GET_REQUEST_RESULT  = new ServiceAction("OFFLINESTORE:GET_REQUEST_RESULT");
+
+
+    /**
+     * List current offline storage requests. Completed jobs may remain in this list
+     * for a provider-specific amount of time.
+     * @param bucket name of bucket to list requests for
+     * @return iterable of current known requests
+     * @throws CloudException
+     * @throws InternalException
+     */
+    public @Nonnull Iterable<OfflineStoreRequest> listRequests(@Nonnull String bucket) throws CloudException, InternalException;
+
+    /**
+     * Get a specific offline storage request
+     * @param bucket name of bucket for request
+     * @param requestId provider-specific identifier of request
+     * @return a representation of the request, or null if it is not found
+     * @throws CloudException
+     * @throws InternalException
+     */
+    public @Nullable OfflineStoreRequest getRequest(@Nonnull String bucket, @Nonnull String requestId) throws CloudException, InternalException;
+
+    /**
+     * Create a new bucket list request
+     * @param bucket name of bucket to list
+     * @return representation of the request
+     * @throws CloudException
+     * @throws InternalException
+     */
+    public @Nonnull OfflineStoreRequest createListRequest(@Nonnull String bucket) throws CloudException, InternalException;
+
+    /**
+     * Create a new object download request
+     * @param bucket name of bucket containing object
+     * @param object name of object to download
+     * @return representation of the request
+     * @throws CloudException
+     * @throws InternalException
+     */
+    public @Nonnull OfflineStoreRequest createDownloadRequest(@Nonnull String bucket, @Nonnull String object) throws CloudException, InternalException;
+
+    /**
+     * Retrieve the results of a completed list request. Will fail if the request is not complete.
+     * @param bucket name of bucket for request
+     * @param requestId provider-specific identifier of request
+     * @return iterable of found objects
+     * @throws InternalException
+     * @throws CloudException
+     */
+    public @Nonnull Iterable<Blob> getListRequestResult(@Nonnull String bucket, @Nonnull String requestId) throws InternalException, CloudException;
+
+    /**
+     * Initiate the download for a request. Will fail if the request is not complete.
+     * @param bucket name of bucket for request
+     * @param requestId provider-specific identifier of request
+     * @param toFile destination file for download results
+     * @return FileTransfer asynchronous object to track the progress of the download
+     * @throws InternalException
+     * @throws CloudException
+     */
+    public @Nonnull FileTransfer getDownloadRequestResult(@Nonnull String bucket, @Nonnull String requestId, @Nonnull File toFile) throws InternalException, CloudException;
+
+}

--- a/src/main/java/org/dasein/cloud/storage/StorageServices.java
+++ b/src/main/java/org/dasein/cloud/storage/StorageServices.java
@@ -48,7 +48,7 @@ public interface StorageServices {
      * to fetch.
      * @return blob store support for the offline storage, if it exists
      */
-    public abstract @Nullable BlobStoreSupport getOfflineStorageSupport();
+    public abstract @Nullable OfflineStoreSupport getOfflineStorageSupport();
 
     /**
      * @return true if the cloud supports offline storage


### PR DESCRIPTION
`OfflineStoreSupport` extends `BlobStoreSupport` and adds support for long-running requests. These requests can be for bucket listing or object downloads and may take hours to complete. Requests can be created and their status can be queried. When complete, their results can be downloaded.
