### PR TITLE
Relax Blob.getInstance() to allow null objectName

### DIFF
--- a/src/main/java/org/dasein/cloud/storage/Blob.java
+++ b/src/main/java/org/dasein/cloud/storage/Blob.java
@@ -44,7 +44,7 @@ public class Blob implements Comparable<Blob> {
         return blob;
     }
 
-    static public @Nonnull Blob getInstance(@Nonnull String providerRegionId, @Nonnull String location, @Nullable String bucketName, @Nonnull String objectName, @Nonnegative long creationTimestamp, @Nonnull Storage<?> size) {
+    static public @Nonnull Blob getInstance(@Nonnull String providerRegionId, @Nonnull String location, @Nullable String bucketName, String objectName, @Nonnegative long creationTimestamp, @Nonnull Storage<?> size) {
         Blob blob = new Blob();
 
         blob.creationTimestamp = creationTimestamp;


### PR DESCRIPTION
Glacier support uses this method to represent vaults, which have a size but not object name. Currently `@Nonnull` only results in IDE warnings but eventually we want violations to fail builds.

This fix not NOT need to be in 2013.07, as we are currently stifling the warning there.
