### PR TITLE
added supportsFirewallDeletion method for clouds which allow creation but not deletion

### DIFF
--- a/src/main/java/org/dasein/cloud/network/AbstractFirewallSupport.java
+++ b/src/main/java/org/dasein/cloud/network/AbstractFirewallSupport.java
@@ -340,6 +340,11 @@ public abstract class AbstractFirewallSupport implements FirewallSupport {
     }
 
     @Override
+    public boolean supportsFirewallDeletion() throws CloudException, InternalException {
+        return true;
+    }
+
+    @Override
     public boolean supportsFirewallSources() throws CloudException, InternalException {
         return false;
     }

--- a/src/main/java/org/dasein/cloud/network/FirewallSupport.java
+++ b/src/main/java/org/dasein/cloud/network/FirewallSupport.java
@@ -451,6 +451,14 @@ public interface FirewallSupport extends AccessControlledService {
     public boolean supportsFirewallCreation(boolean inVlan) throws CloudException, InternalException;
 
     /**
+     * Indicates whether or not you can delete firewalls.
+     * @return <code>true</code> if you can call {@link #delete(String)} to delete a firewall
+     * @throws CloudException an error occurred with the cloud provider while checking for support
+     * @throws InternalException a local error occurred while checking for support
+     */
+    public boolean supportsFirewallDeletion() throws CloudException, InternalException;
+
+    /**
      * Indicates whether or the sources you specify in your rules may be other firewalls (security group behavior).
      * @return true if the sources may be other firewalls
      * @throws CloudException an error occurred with the cloud provider while checking for support


### PR DESCRIPTION
added to FirewallSupport interface and AbstractFirewallSupport
related to issue #111
