### PR TITLE
Added collection of volumes to VirtualMachine

### DIFF
--- a/src/main/java/org/dasein/cloud/compute/VirtualMachine.java
+++ b/src/main/java/org/dasein/cloud/compute/VirtualMachine.java
@@ -71,6 +71,7 @@ public class VirtualMachine implements Networkable, Taggable {
     private String                providerVlanId;
     private String                providerKeypairId;
     private String[]              providerFirewallIds;
+    private String[]              providerVolumeIds;
     private String                publicDnsAddress;
     private RawAddress[]          publicIpAddresses;
     private boolean               rebootable;
@@ -508,6 +509,14 @@ public class VirtualMachine implements Networkable, Taggable {
     public void setProviderFirewallIds( String[] providerFirewallIds ) {
       this.providerFirewallIds = providerFirewallIds;
     }
+
+    public String[] getProviderVolumeIds() {
+       return (providerVolumeIds == null ? new String[0] : providerVolumeIds);
+     }
+
+    public void setProviderVolumeIds( String[] providerVolumeIds ) {
+       this.providerVolumeIds = providerVolumeIds;
+     }
 
     public @Nullable String getProviderKernelImageId() {
         return providerKernelImageId;


### PR DESCRIPTION
When AWS returns information about a VM instance, it includes the ids of the volumes attached to the instance if the instance is using EBS. It would be nice if the VirtualMachine class provided that information; having it there is a lot easier than having to query all of the volumes and then scan the volumes to determine which ones are attached to the instance in question.

This is part 1 of the patch for dasein-cloud-aws issue #87.
