### PR TITLE
Adding a missing getter VMLaunchOptions#getSubnetId(). This is required ...

### DIFF
--- a/src/main/java/org/dasein/cloud/compute/VMLaunchOptions.java
+++ b/src/main/java/org/dasein/cloud/compute/VMLaunchOptions.java
@@ -392,7 +392,14 @@ public class VMLaunchOptions {
     public @Nullable String getUserData() {
         return userData;
     }
-    
+
+    /**
+     * @return the subnet which the launch VM is going to be assigned to
+     */
+    public @Nullable String getSubnetId() {
+        return subnetId;
+    }
+
     /**
      * @return the VLAN or subnet into which the virtual machine will be launched
      */


### PR DESCRIPTION
...for AWS driver to work properly.
