### PR TITLE
MachineImage now contains minimum required disk size. defaults to 10gb

### DIFF
--- a/src/main/java/org/dasein/cloud/compute/MachineImage.java
+++ b/src/main/java/org/dasein/cloud/compute/MachineImage.java
@@ -80,9 +80,11 @@ public class MachineImage implements Taggable {
         image.type = MachineImageType.VOLUME;
         image.creationTimestamp = 0L;
         image.software = "";
+        image.minimumDiskSizeGb = 10L;
         return image;
     }
 
+    private long               minimumDiskSizeGb;
     private Architecture       architecture;
     private long               creationTimestamp;
     private MachineImageState  currentState;
@@ -721,6 +723,14 @@ public class MachineImage implements Taggable {
         image.software = "";
         image.visibleScope = visibleScope;
         return image;
+    }
+
+    public long getMinimumDiskSizeGb() {
+        return minimumDiskSizeGb;
+    }
+
+    public void setMinimumDiskSizeGb(long minimumDiskSizeGb) {
+        this.minimumDiskSizeGb = minimumDiskSizeGb;
     }
 
 }


### PR DESCRIPTION
if not specified.
