### PR TITLE
LB to support listener level health check

### DIFF
--- a/src/main/java/org/dasein/cloud/network/HealthCheckOptions.java
+++ b/src/main/java/org/dasein/cloud/network/HealthCheckOptions.java
@@ -91,18 +91,6 @@ public class HealthCheckOptions {
         return options;
     }
 
-    /**
-     * Create HealthCheckOptions instance
-     * @see HealthCheckOptions#getInstance(String, String, String, String, LoadBalancerHealthCheck.HCProtocol, int, String, int, int, int, int);
-     * @param lbListener
-     *          The specified load balancer listener that this health check will be associated to..
-     */
-    public static HealthCheckOptions getInstance(@Nullable String name, @Nullable String description, @Nullable String providerLoadBalancerId, @Nullable LbListener lbListener, @Nullable String host, @Nullable LoadBalancerHealthCheck.HCProtocol protocol, int port, @Nullable String path, int interval, int timeout, int healthyCount, int unhealthyCount){
-        HealthCheckOptions options = getInstance(name, description, providerLoadBalancerId, host, protocol, port, path, interval, timeout, healthyCount, unhealthyCount);
-        options.listener = lbListener;
-        return options;
-    }
-
     public @Nonnull LoadBalancerHealthCheck build(@Nonnull CloudProvider provider) throws CloudException, InternalException {
         NetworkServices services = provider.getNetworkServices();
 
@@ -222,6 +210,16 @@ public class HealthCheckOptions {
      */
     public @Nonnull HealthCheckOptions withProviderLoadBalancerId(@Nonnull String providerLoadBalancerId){
         this.providerLoadBalancerId = providerLoadBalancerId;
+        return this;
+    }
+
+    /**
+     * For listener level health check, sets the listener which the health check is attached
+     * @param lbListener the LbListener to which the Health Check is attached
+     * @return this
+     */
+    public @Nonnull HealthCheckOptions withListener(@Nullable LbListener lbListener) {
+        this.listener = lbListener;
         return this;
     }
 

--- a/src/main/java/org/dasein/cloud/network/HealthCheckOptions.java
+++ b/src/main/java/org/dasein/cloud/network/HealthCheckOptions.java
@@ -36,6 +36,7 @@ public class HealthCheckOptions {
     private String                             name;
     private String                             description;
     private String                             providerLoadBalancerId;
+    private LbListener                         listener;
     private String                             host;
     private LoadBalancerHealthCheck.HCProtocol protocol;
     private int                                port;
@@ -90,6 +91,18 @@ public class HealthCheckOptions {
         return options;
     }
 
+    /**
+     * Create HealthCheckOptions instance
+     * @see HealthCheckOptions#getInstance(String, String, String, String, LoadBalancerHealthCheck.HCProtocol, int, String, int, int, int, int);
+     * @param lbListener
+     *          The specified load balancer listener that this health check will be associated to..
+     */
+    public static HealthCheckOptions getInstance(@Nullable String name, @Nullable String description, @Nullable String providerLoadBalancerId, @Nullable LbListener lbListener, @Nullable String host, @Nullable LoadBalancerHealthCheck.HCProtocol protocol, int port, @Nullable String path, int interval, int timeout, int healthyCount, int unhealthyCount){
+        HealthCheckOptions options = getInstance(name, description, providerLoadBalancerId, host, protocol, port, path, interval, timeout, healthyCount, unhealthyCount);
+        options.listener = lbListener;
+        return options;
+    }
+
     public @Nonnull LoadBalancerHealthCheck build(@Nonnull CloudProvider provider) throws CloudException, InternalException {
         NetworkServices services = provider.getNetworkServices();
 
@@ -127,6 +140,14 @@ public class HealthCheckOptions {
 
     public void setLoadBalancerId(String providerLoadBalancerId){
         this.providerLoadBalancerId = providerLoadBalancerId;
+    }
+
+    public @Nullable LbListener getListener() {
+        return listener;
+    }
+
+    public void setListener(@Nullable LbListener lbListener) {
+        this.listener = lbListener;
     }
 
     public @Nullable String getHost() {
@@ -203,4 +224,5 @@ public class HealthCheckOptions {
         this.providerLoadBalancerId = providerLoadBalancerId;
         return this;
     }
+
 }

--- a/src/main/java/org/dasein/cloud/network/LbListener.java
+++ b/src/main/java/org/dasein/cloud/network/LbListener.java
@@ -198,6 +198,16 @@ public class LbListener {
     }
 
     /**
+     * Sets the SSL Certificate Name assoicated with this listener
+     * @param sslCertificateName the SSL Certificate name
+     * @return this
+     */
+    public @Nonnull LbListener withSslCertificateName(@Nullable String sslCertificateName) {
+        this.sslCertificateName = sslCertificateName;
+        return this;
+    }
+
+    /**
      * Sets the Health Check ID associated with this listener
      * @param providerLBHealthCheckId the Health Check ID
      * @return this

--- a/src/main/java/org/dasein/cloud/network/LbListener.java
+++ b/src/main/java/org/dasein/cloud/network/LbListener.java
@@ -64,9 +64,9 @@ public class LbListener {
      * @return a newly constructed listener
      */
     static public LbListener getInstance(@Nonnull LbProtocol protocol, int publicPort, int privatePort,
-                                         String sslCertificateName) {
+            String sslCertificateName) {
         return new LbListener(LbAlgorithm.ROUND_ROBIN, LbPersistence.NONE, protocol, publicPort, privatePort,
-                              sslCertificateName);
+                sslCertificateName);
     }
 
     /**
@@ -102,6 +102,13 @@ public class LbListener {
         return new LbListener(algorithm, persistence, protocol, publicPort, privatePort);
     }
 
+    static public LbListener getInstance(@Nonnull LbAlgorithm algorithm, @Nonnull LbPersistence persistence, @Nullable String cookie, @Nonnull LbProtocol protocol, int publicPort, int privatePort, @Nullable String sslCertificateName, @Nullable String providerLBHealthCheckId) {
+        LbListener lbListener = new LbListener(algorithm, persistence, protocol, publicPort, privatePort, sslCertificateName);
+        lbListener.cookie = cookie;
+        lbListener.providerLBHealthCheckId = providerLBHealthCheckId;
+        return lbListener;
+    }
+
     private LbAlgorithm   algorithm;
     private String        cookie;
     private LbProtocol    networkProtocol;
@@ -109,6 +116,7 @@ public class LbListener {
     private int           privatePort;
     private int           publicPort;
     private String        sslCertificateName;
+    private String        providerLBHealthCheckId;
 
     /**
      * Constructs an empty listener object.
@@ -121,7 +129,7 @@ public class LbListener {
     }
 
     public LbListener(@Nonnull LbAlgorithm algorithm, @Nonnull LbPersistence persistence, @Nonnull LbProtocol protocol,
-                      int publicPort, int privatePort, @Nullable String sslCertificateName) {
+            int publicPort, int privatePort, @Nullable String sslCertificateName) {
         this.algorithm = algorithm;
         this.persistence = persistence;
         this.networkProtocol = protocol;
@@ -187,6 +195,13 @@ public class LbListener {
      */
     public String getSslCertificateName() {
         return sslCertificateName;
+    }
+
+    /**
+     * @return the ID of a Health Check if one is attached.
+     */
+    public @Nullable String getProviderLBHealthCheckId(){
+        return providerLBHealthCheckId;
     }
 
     @Override

--- a/src/main/java/org/dasein/cloud/network/LbListener.java
+++ b/src/main/java/org/dasein/cloud/network/LbListener.java
@@ -102,13 +102,6 @@ public class LbListener {
         return new LbListener(algorithm, persistence, protocol, publicPort, privatePort);
     }
 
-    static public LbListener getInstance(@Nonnull LbAlgorithm algorithm, @Nonnull LbPersistence persistence, @Nullable String cookie, @Nonnull LbProtocol protocol, int publicPort, int privatePort, @Nullable String sslCertificateName, @Nullable String providerLBHealthCheckId) {
-        LbListener lbListener = new LbListener(algorithm, persistence, protocol, publicPort, privatePort, sslCertificateName);
-        lbListener.cookie = cookie;
-        lbListener.providerLBHealthCheckId = providerLBHealthCheckId;
-        return lbListener;
-    }
-
     private LbAlgorithm   algorithm;
     private String        cookie;
     private LbProtocol    networkProtocol;
@@ -203,6 +196,17 @@ public class LbListener {
     public @Nullable String getProviderLBHealthCheckId(){
         return providerLBHealthCheckId;
     }
+
+    /**
+     * Sets the Health Check ID associated with this listener
+     * @param providerLBHealthCheckId the Health Check ID
+     * @return this
+     */
+    public @Nonnull LbListener withProviderLBHealthCheckId(@Nullable String providerLBHealthCheckId) {
+        this.providerLBHealthCheckId = providerLBHealthCheckId;
+        return this;
+    }
+
 
     @Override
     public @Nonnull String toString() {

--- a/src/main/java/org/dasein/cloud/network/LoadBalancerCapabilities.java
+++ b/src/main/java/org/dasein/cloud/network/LoadBalancerCapabilities.java
@@ -74,6 +74,14 @@ public interface LoadBalancerCapabilities extends Capabilities{
     boolean healthCheckRequiresLoadBalancer() throws CloudException, InternalException;
 
     /**
+     * Indicates whether a health check can be created independently of a listener.
+     * @return false if health check can exist without having been assigned to a listener
+     * @throws CloudException an error occurred while communicating with the cloud provider
+     * @throws InternalException an error occurred within the Dasein Cloud implementation
+     */
+    boolean healthCheckRequiresListener() throws CloudException, InternalException;
+
+    /**
      * Indicates whether a name is required when creating a health check
      * @return Requirement for health check name
      * @throws CloudException
@@ -111,14 +119,6 @@ public interface LoadBalancerCapabilities extends Capabilities{
      * @throws InternalException an error occurred within the Dasein Cloud implementation
      */
     @Nonnull Requirement identifyHealthCheckOnCreateRequirement() throws CloudException, InternalException;
-
-    /**
-     * Indicates whether a health check requires a listener to be specified when it is created/updated.
-     * @return the degree to which a listener should or must be part of health check creation process
-     * @throws CloudException an error occurred while communicating with the cloud provider
-     * @throws InternalException an error occurred within the Dasein Cloud implementation
-     */
-    public @Nonnull Requirement identityListenerOnHealthCheckRequirement() throws CloudException, InternalException;
 
     /**
      * @return whether or not you are expected to provide an address as part of the create process or one gets assigned

--- a/src/main/java/org/dasein/cloud/network/LoadBalancerCapabilities.java
+++ b/src/main/java/org/dasein/cloud/network/LoadBalancerCapabilities.java
@@ -113,6 +113,14 @@ public interface LoadBalancerCapabilities extends Capabilities{
     @Nonnull Requirement identifyHealthCheckOnCreateRequirement() throws CloudException, InternalException;
 
     /**
+     * Indicates whether a health check requires a listener to be specified when it is created/updated.
+     * @return the degree to which a listener should or must be part of health check creation process
+     * @throws CloudException an error occurred while communicating with the cloud provider
+     * @throws InternalException an error occurred within the Dasein Cloud implementation
+     */
+    public @Nonnull Requirement identityListenerOnHealthCheckRequirement() throws CloudException, InternalException;
+
+    /**
      * @return whether or not you are expected to provide an address as part of the create process or one gets assigned
      *         by the provider
      * @throws CloudException    an error occurred while communicating with the cloud provider

--- a/src/main/java/org/dasein/cloud/network/LoadBalancerHealthCheck.java
+++ b/src/main/java/org/dasein/cloud/network/LoadBalancerHealthCheck.java
@@ -38,6 +38,7 @@ public class LoadBalancerHealthCheck implements Networkable{
     private String            name;
     private String            description;
     private List<String>      providerLoadBalancerIds = new ArrayList<String>();
+    private List<LbListener>  listeners = new ArrayList<LbListener>();
     private String            host;
     private HCProtocol        protocol;
     private int               port;
@@ -108,6 +109,18 @@ public class LoadBalancerHealthCheck implements Networkable{
 
     public void removeProviderLoadBalancerId(String providerLoadBalancerId){
         this.providerLoadBalancerIds.remove(providerLoadBalancerId);
+    }
+
+    public List<LbListener> getListeners() {
+        return listeners;
+    }
+
+    public void addListener(LbListener listener) {
+        this.listeners.add(listener);
+    }
+
+    public void removeListener(LbListener listener) {
+        this.listeners.remove(listener);
     }
 
     public String getHost() {


### PR DESCRIPTION
Health check of Aliyun is associated with listener, not load balancer.
Enable dasein to support listener level heath check, currently only
enabled on create/update health check method which allow specify listen
the health check is for.
